### PR TITLE
require fallback

### DIFF
--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -9,27 +9,27 @@ on:
         - 'docs/**'
         - '*.md'
 jobs:
-  # pnpm:
-  #   name: pnpm package manager on ${{ matrix.node-version }} ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [macOS-latest, windows-latest]
-  #       node-version: [12, 14, 16]
-  #   steps:
-  #     - uses: actions/checkout@v2.3.4
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v2.4.0
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #     - name: Use pnpm
-  #       uses: pnpm/action-setup@v2.0.1
-  #       with:
-  #         version: ^6.0.0
-  #     - name: Install dependancies
-  #       run: pnpm install
-  #     - name: Tests
-  #       run: pnpm run test:ci
+  pnpm:
+    name: pnpm package manager on ${{ matrix.node-version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-latest]
+        node-version: [12, 14, 16]
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Use pnpm
+        uses: pnpm/action-setup@v2.0.1
+        with:
+          version: ^6.0.0
+      - name: Install dependancies
+        run: pnpm install
+      - name: Tests
+        run: pnpm run test:ci
 
   yarn-pnp:
     name: yarn-pnp package manager on ${{ matrix.node-version }} ${{ matrix.os }}

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -48,8 +48,9 @@ jobs:
         run: |
           npm install -g yarn
           yarn set version berry
-          echo "nodeLinker: pnp" >> .yarnrc.yml 
-          echo "pnpMode: loose" >> .yarnrc.yml 
+          echo "nodeLinker: pnp" >> .yarnrc.yml
+          echo "pnpMode: loose" >> .yarnrc.yml
+          yarn add -D pino-elasticsearch@^6.0.0
           yarn install
         env:
           # needed due the yarn.lock file in repository's .gitignore

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -1,0 +1,58 @@
+name: package-manager-ci
+on:
+  push:
+    paths-ignore:
+        - 'docs/**'
+        - '*.md'
+  pull_request:
+    paths-ignore:
+        - 'docs/**'
+        - '*.md'
+jobs:
+  # pnpm:
+  #   name: pnpm package manager on ${{ matrix.node-version }} ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [macOS-latest, windows-latest]
+  #       node-version: [12, 14, 16]
+  #   steps:
+  #     - uses: actions/checkout@v2.3.4
+  #     - name: Use Node.js ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v2.4.0
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #     - name: Use pnpm
+  #       uses: pnpm/action-setup@v2.0.1
+  #       with:
+  #         version: ^6.0.0
+  #     - name: Install dependancies
+  #       run: pnpm install
+  #     - name: Tests
+  #       run: pnpm run test:ci
+
+  yarn-pnp:
+    name: yarn-pnp package manager on ${{ matrix.node-version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest]
+        node-version: [12, 14, 16]
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Use yarn
+        run: |
+          npm install -g yarn
+          yarn set version berry
+          echo "nodeLinker: pnp" >> .yarnrc.yml 
+          echo "pnpMode: loose" >> .yarnrc.yml 
+          yarn install
+        env:
+          # needed due the yarn.lock file in repository's .gitignore
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      - name: Tests
+        run: yarn run test:yarn

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ typings/
 # Optional npm cache directory
 .npm
 
+# Yarn files
+.yarn
+.yarnrc.yml
+.pnp.cjs
+yarn.lock
+
 # Optional eslint cache
 .eslintcache
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ flag your stream classes.
 
 The underlining worker is automatically closed if the stream is garbage collected.
 
+
+### External modules
+
+You may use this module within compatible external modules, that exports the `worker.js` interface.
+
+```js
+const ThreadStream = require('thread-stream')
+
+const modulePath = require.resolve('pino-elasticsearch')
+
+const stream = new ThreadStream({
+  filename: modulePath,
+  workerData: { node: 'http://localhost:9200' }
+})
+
+stream.write('log to elasticsearch!')
+stream.flushSync()
+stream.end()
+```
+
+This module works with `yarn` in PnP (plug'n play) mode too!
+
 ## License
 
 MIT

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -19,7 +19,8 @@ async function start () {
   try {
     fn = (await import(workerData.filename)).default
   } catch (error) {
-    if (error.code === 'ENOTDIR' && workerData.filename.startsWith('file://')) {
+    if ((error.code === 'ENOTDIR' || error.code === 'ERR_MODULE_NOT_FOUND') &&
+     workerData.filename.startsWith('file://')) {
       fn = require(workerData.filename.replace('file://', ''))
     } else {
       throw error

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -19,6 +19,14 @@ async function start () {
   try {
     fn = (await import(workerData.filename)).default
   } catch (error) {
+    // A yarn user that tries to start a ThreadStream for an external module
+    // provides a filename pointing to a zip file.
+    // eg. require.resolve('pino-elasticsearch') // returns /foo/pino-elasticsearch-npm-6.1.0-0c03079478-6915435172.zip/bar.js
+    // The `import` will fail to try to load it.
+    // This catch block executes the `require` fallback to load the module correctly.
+    // In fact, yarn modifies the `require` function to manage the zipped path.
+    // More details at https://github.com/pinojs/pino/pull/1113
+    // The error codes may change based on the node.js version (ENOTDIR > 12, ERR_MODULE_NOT_FOUND <= 12 )
     if ((error.code === 'ENOTDIR' || error.code === 'ERR_MODULE_NOT_FOUND') &&
      workerData.filename.startsWith('file://')) {
       fn = require(workerData.filename.replace('file://', ''))

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -15,7 +15,16 @@ const state = new Int32Array(stateBuf)
 const data = Buffer.from(dataBuf)
 
 async function start () {
-  const fn = (await import(workerData.filename)).default
+  let fn
+  try {
+    fn = (await import(workerData.filename)).default
+  } catch (error) {
+    if(error.code === 'ENOTDIR' && workerData.filename.startsWith('file://')) {
+      fn = require(workerData.filename.replace('file://', ''))
+    } else {
+      throw error
+    }
+  }
   destination = await fn(workerData.workerData)
 
   destination.on('error', function (err) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -19,7 +19,7 @@ async function start () {
   try {
     fn = (await import(workerData.filename)).default
   } catch (error) {
-    if(error.code === 'ENOTDIR' && workerData.filename.startsWith('file://')) {
+    if (error.code === 'ENOTDIR' && workerData.filename.startsWith('file://')) {
       fn = require(workerData.filename.replace('file://', ''))
     } else {
       throw error

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "desm": "^1.1.0",
     "fastbench": "^1.0.1",
     "husky": "^7.0.0",
+    "pino-elasticsearch": "^6.1.0",
     "sonic-boom": "^2.0.1",
     "standard": "^16.0.3",
     "tap": "^15.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "standard && tap --no-check-coverage test/*.test.*js",
     "test:ci": "standard && tap \"test/**/*.test.*js\" --no-check-coverage --coverage-report=lcovonly",
-    "test:yarn": "standard && tap \"test/**/*.test.js\" --no-check-coverage --coverage-report=lcovonly",
+    "test:yarn": "tap \"test/**/*.test.js\" --no-check-coverage",
     "prepare": "husky install"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "desm": "^1.1.0",
     "fastbench": "^1.0.1",
     "husky": "^7.0.0",
-    "pino-elasticsearch": "^6.1.0",
     "sonic-boom": "^2.0.1",
     "standard": "^16.0.3",
     "tap": "^15.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "standard && tap --no-check-coverage test/*.test.*js",
     "test:ci": "standard && tap \"test/**/*.test.*js\" --no-check-coverage --coverage-report=lcovonly",
+    "test:yarn": "standard && tap \"test/**/*.test.js\" --no-check-coverage --coverage-report=lcovonly",
     "prepare": "husky install"
   },
   "repository": {

--- a/test/commonjs-fallback.test.js
+++ b/test/commonjs-fallback.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('tap')
+const ThreadStream = require('..')
+
+const isYarnPnp = process.versions.pnp !== undefined
+
+test('yarn module resolution', { skip: !isYarnPnp }, t => {
+  t.plan(5)
+
+  const modulePath = require.resolve('pino-elasticsearch')
+  t.match(modulePath, /.*\.zip.*/)
+
+  const stream = new ThreadStream({
+    filename: modulePath,
+    workerData: { node: null },
+    sync: true
+  })
+
+  stream.on('error', (err) => {
+    t.pass('error emitted')
+    t.equal(err.message, 'Missing node(s) option', 'module custom error')
+  })
+
+  t.ok(stream.write('hello world\n'))
+  t.ok(stream.writable)
+
+  stream.end()
+})
+

--- a/test/commonjs-fallback.test.js
+++ b/test/commonjs-fallback.test.js
@@ -27,4 +27,3 @@ test('yarn module resolution', { skip: !isYarnPnp }, t => {
 
   stream.end()
 })
-


### PR DESCRIPTION
Adding the `require` fallback to support `yarn` in PnP mode.

Added workflows to test it.
Note I had to add a new script in package.json because the `mjs` files do not work with yarn (it doesn't support esm yet)

There is a repetitive warnings in the output

```
test/thread-management.test.js 2> (node:3755) [MODULE_NOT_FOUND] Error: debug tried to access supports-color (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.
```

caused by some dependencies that have not added the module into their package json.
Not sure it is worth some investigation

Reference https://github.com/pinojs/pino/pull/1113