### PR TITLE
feat: Support bundlers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ const registry = new FinalizationRegistry((worker) => {
 function createWorker (stream, opts) {
   const { filename, workerData } = opts
 
-  const toExecute = join(__dirname, 'lib', 'worker.js')
+  const bundlerOverrides = '__bundlerPathsOverrides' in globalThis ? globalThis.__bundlerPathsOverrides : {}
+  const toExecute = bundlerOverrides['thread-stream-worker'] || join(__dirname, 'lib', 'worker.js')
 
   const worker = new Worker(toExecute, {
     ...opts.workerOpts,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { realImport, realRequire } = require('real-require')
 const { workerData, parentPort } = require('worker_threads')
 const { WRITE_INDEX, READ_INDEX } = require('./indexes')
 const { waitDiff } = require('./wait')
@@ -17,7 +18,7 @@ const data = Buffer.from(dataBuf)
 async function start () {
   let fn
   try {
-    fn = (await import(workerData.filename)).default
+    fn = (await realImport(workerData.filename)).default
   } catch (error) {
     // A yarn user that tries to start a ThreadStream for an external module
     // provides a filename pointing to a zip file.
@@ -29,7 +30,7 @@ async function start () {
     // The error codes may change based on the node.js version (ENOTDIR > 12, ERR_MODULE_NOT_FOUND <= 12 )
     if ((error.code === 'ENOTDIR' || error.code === 'ERR_MODULE_NOT_FOUND') &&
      workerData.filename.startsWith('file://')) {
-      fn = require(workerData.filename.replace('file://', ''))
+      fn = realRequire(workerData.filename.replace('file://', ''))
     } else {
       throw error
     }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.12.1",
   "description": "A streaming way to send data to a Node.js Worker Thread",
   "main": "index.js",
+  "dependencies": {
+    "real-require": "^0.1.0"
+  },
   "devDependencies": {
     "desm": "^1.1.0",
     "fastbench": "^1.0.1",

--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { test } = require('tap')
+const { join } = require('path')
+const { file } = require('./helper')
+const ThreadStream = require('..')
+
+test('bundlers support', function (t) {
+  t.plan(1)
+
+  globalThis.__bundlerPathsOverrides = {
+    'thread-stream-worker': join(__dirname, 'custom-worker.js')
+  }
+
+  const dest = file()
+
+  process.on('uncaughtException', error => {
+    console.log(error)
+  })
+
+  const stream = new ThreadStream({
+    filename: join(__dirname, 'to-file.js'),
+    workerData: { dest },
+    sync: true
+  })
+
+  stream.worker.removeAllListeners('message')
+  stream.worker.once('message', message => {
+    t.equal(message.code, 'CUSTOM-WORKER-CALLED')
+  })
+
+  stream.end()
+})

--- a/test/custom-worker.js
+++ b/test/custom-worker.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { parentPort } = require('worker_threads')
+
+parentPort.postMessage({
+  code: 'CUSTOM-WORKER-CALLED'
+})
+
+require('../lib/worker')


### PR DESCRIPTION
This PR add supports for using thread-stream in bundled source files.
In particular:

* It uses [real-require](https://github.com/pinojs/real-require) to perform dynamic requires/import.
* It add support for a global variable `__bundlerPathsOverrides` which bundler plugins can set to override require paths if needed.
