### PR TITLE
windows pathing fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: fastify/github-action-merge-dependabot@v2.6.0
+      - uses: fastify/github-action-merge-dependabot@v2.7.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
import will not universally work on all node.js use-cases like pkg for example. I made fix to handover the module loading to require in node.js for better compatibility.

when removing the 'file://' from path, in windows, it will leave a leading '/' in the path that will make the worker module loading fail.