### PR TITLE
Avoid zalgo when calling flush().

### DIFF
--- a/test/base.test.js
+++ b/test/base.test.js
@@ -246,3 +246,26 @@ test('pass down MessagePorts', async function (t) {
 
   t.equal(strings, 'hello world\nsomething else\n')
 })
+
+test('destroy does not error', function (t) {
+  t.plan(3)
+
+  const dest = file()
+  const stream = new ThreadStream({
+    filename: join(__dirname, 'to-file.js'),
+    workerData: { dest },
+    sync: false
+  })
+
+  stream.on('ready', () => {
+    t.pass('ready emitted')
+    stream.worker.terminate()
+  })
+
+  stream.on('error', (err) => {
+    t.equal(err.message, 'The worker thread exited')
+    stream.flush((err) => {
+      t.equal(err.message, 'the worker has exited')
+    })
+  })
+})


### PR DESCRIPTION
Flush could error both synchronously and asynchronously, making it
extremely hard to handle both cases. In case of a race condition it
could even make the error uncatchable.

My understanding is this should fix https://github.com/pinojs/pino/issues/1375. However this is yet to be seen. It definitely fixes some flakiness in our CI.