### PR TITLE
fix: not throw error in flushSync and end functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,9 +249,12 @@ class ThreadStream extends EventEmitter {
     return !this[kImpl].needDrain
   }
 
-  end () {
+  end (cb) {
     if (this[kImpl].destroyed) {
-      throw new Error('the worker has exited')
+      if (typeof cb === 'function') {
+        process.nextTick(cb, new Error('the worker has exited'))
+      }
+      return
     }
 
     this[kImpl].ending = true
@@ -284,9 +287,12 @@ class ThreadStream extends EventEmitter {
     })
   }
 
-  flushSync () {
+  flushSync (cb) {
     if (this[kImpl].destroyed) {
-      throw new Error('the worker has exited')
+      if (typeof cb === 'function') {
+        process.nextTick(cb, new Error('the worker has exited'))
+      }
+      return
     }
 
     writeSync(this)

--- a/index.js
+++ b/index.js
@@ -249,11 +249,8 @@ class ThreadStream extends EventEmitter {
     return !this[kImpl].needDrain
   }
 
-  end (cb) {
+  end () {
     if (this[kImpl].destroyed) {
-      if (typeof cb === 'function') {
-        process.nextTick(cb, new Error('the worker has exited'))
-      }
       return
     }
 
@@ -287,11 +284,8 @@ class ThreadStream extends EventEmitter {
     })
   }
 
-  flushSync (cb) {
+  flushSync () {
     if (this[kImpl].destroyed) {
-      if (typeof cb === 'function') {
-        process.nextTick(cb, new Error('the worker has exited'))
-      }
       return
     }
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -267,11 +267,7 @@ test('destroy does not error', function (t) {
     stream.flush((err) => {
       t.equal(err.message, 'the worker has exited')
     })
-    stream.flushSync((err) => {
-      t.equal(err.message, 'the worker has exited')
-    })
-    stream.end((err) => {
-      t.equal(err.message, 'the worker has exited')
-    })
+    t.doesNotThrow(() => stream.flushSync())
+    t.doesNotThrow(() => stream.end())
   })
 })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -248,7 +248,7 @@ test('pass down MessagePorts', async function (t) {
 })
 
 test('destroy does not error', function (t) {
-  t.plan(3)
+  t.plan(5)
 
   const dest = file()
   const stream = new ThreadStream({
@@ -265,6 +265,12 @@ test('destroy does not error', function (t) {
   stream.on('error', (err) => {
     t.equal(err.message, 'The worker thread exited')
     stream.flush((err) => {
+      t.equal(err.message, 'the worker has exited')
+    })
+    stream.flushSync((err) => {
+      t.equal(err.message, 'the worker has exited')
+    })
+    stream.end((err) => {
       t.equal(err.message, 'the worker has exited')
     })
   })


### PR DESCRIPTION
Closes #73 

we should apply the same logic made [here](https://github.com/pinojs/thread-stream/commit/ff7c9be4395ac871796773918a385a127c2be52f#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R262)  in `flushSync` and `end` functions.

discussion: https://github.com/pinojs/pino-socket/issues/59

