### PR TITLE
Emit errors instead of throwing errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,73 @@
 import { EventEmitter } from 'events'
+import workerThreads from 'worker_threads'
+
+interface ThreadStreamOptions {
+  /**
+   * The size (in bytes) of the buffer.
+   * Must be greater than 4 (i.e. it must at least fit a 4-byte utf-8 char).
+   * 
+   * Default: `4 * 1024 * 1024` = `4194304`
+   */
+  bufferSize?: number,
+  /**
+   * The path to the Worker's main script or module.
+   * Must be either an absolute path or a relative path (i.e. relative to the current working directory) starting with ./ or ../, or a WHATWG URL object using file: or data: protocol.
+   * When using a data: URL, the data is interpreted based on MIME type using the ECMAScript module loader.
+   * 
+   * {@link workerThreads.Worker()}
+   */
+  filename: string | URL,
+  /**
+   * If `true`, write data synchronously; otherwise write data asynchronously.
+   * 
+   * Default: `false`.
+   */
+  sync?: boolean,
+  /**
+   * {@link workerThreads.WorkerOptions.workerData}
+   * 
+   * Default: `{}`
+   */
+  workerData?: any,
+  /**
+   * {@link workerThreads.WorkerOptions}
+   * 
+   * Default: `{}`
+   */
+  workerOpts?: workerThreads.WorkerOptions
+}
+
 
 declare class ThreadStream extends EventEmitter {
-  constructor(opts: {})
-  write (data: string): boolean
-  end (): void
+  /**
+   * @param {ThreadStreamOptions} opts 
+   */
+  constructor(opts: ThreadStreamOptions)
+  /**
+   * Write some data to the stream.
+   * 
+   * **Please note that this method should not throw an {Error} if something goes wrong but emit an error event.**
+   * @param {string} data data to write.
+   * @returns {boolean} false if the stream wishes for the calling code to wait for the 'drain' event to be emitted before continuing to write additional data or if it fails to write; otherwise true.
+   */
+  write(data: string): boolean
+  /**
+   * Signal that no more data will be written.
+   * 
+   * **Please note that this method should not throw an {Error} if something goes wrong but emit an error event.**
+   * 
+   * Calling the {@link write()} method after calling {@link end()} will emit an error.
+   */
+  end(): void
+  /**
+   * Flush the stream synchronously.
+   * This method should be called in the shutdown phase to make sure that all data has been flushed.
+   * 
+   * **Please note that this method will throw an {Error} if something goes wrong.**
+   * 
+   * @throws {Error} if the stream is already flushing, if it fails to flush or if it takes more than 10 seconds to flush.
+   */
+  flushSync(): void
 }
 
 export = ThreadStream;

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function nextFlush (stream) {
     })
   } else {
     // This should never happen
-    throw new Error('overwritten')
+    destroy(stream, new Error('overwritten'))
   }
 }
 
@@ -164,7 +164,7 @@ function onWorkerMessage (msg) {
       destroy(stream, msg.err)
       break
     default:
-      throw new Error('this should not happen: ' + msg.code)
+      destroy(stream, new Error('this should not happen: ' + msg.code))
   }
 }
 
@@ -177,7 +177,7 @@ function onWorkerExit (code) {
   registry.unregister(stream)
   stream.worker.exited = true
   stream.worker.off('exit', onWorkerExit)
-  destroy(stream, code !== 0 ? new Error('The worker thread exited') : null)
+  destroy(stream, code !== 0 ? new Error('the worker thread exited') : null)
 }
 
 class ThreadStream extends EventEmitter {
@@ -211,11 +211,13 @@ class ThreadStream extends EventEmitter {
 
   write (data) {
     if (this[kImpl].destroyed) {
-      throw new Error('the worker has exited')
+      error(this, new Error('the worker has exited'))
+      return false
     }
 
     if (this[kImpl].ending) {
-      throw new Error('the worker is ending')
+      error(this, new Error('the worker is ending'))
+      return false
     }
 
     if (this[kImpl].flushing && this[kImpl].buf.length + data.length >= MAX_STRING) {
@@ -338,6 +340,12 @@ class ThreadStream extends EventEmitter {
   }
 }
 
+function error (stream, err) {
+  setImmediate(() => {
+    stream.emit('error', err)
+  })
+}
+
 function destroy (stream, err) {
   if (stream[kImpl].destroyed) {
     return
@@ -346,7 +354,7 @@ function destroy (stream, err) {
 
   if (err) {
     stream[kImpl].errored = err
-    stream.emit('error', err)
+    error(stream, err)
   }
 
   if (!stream.worker.exited) {
@@ -399,11 +407,13 @@ function end (stream) {
       readIndex = Atomics.load(stream[kImpl].state, READ_INDEX)
 
       if (readIndex === -2) {
-        throw new Error('end() failed')
+        destroy(stream, new Error('end() failed'))
+        return
       }
 
       if (++spins === 10) {
-        throw new Error('end() took too long (10s)')
+        destroy(stream, new Error('end() took too long (10s)'))
+        return
       }
     }
 
@@ -437,7 +447,8 @@ function writeSync (stream) {
       continue
     } else if (leftover < 0) {
       // stream should never happen
-      throw new Error('overwritten')
+      destroy(stream, new Error('overwritten'))
+      return
     }
 
     let toWrite = stream[kImpl].buf.slice(0, leftover)
@@ -468,7 +479,8 @@ function writeSync (stream) {
 
 function flushSync (stream) {
   if (stream[kImpl].flushing) {
-    throw new Error('unable to flush while flushing')
+    destroy(stream, new Error('unable to flush while flushing'))
+    return
   }
 
   // process._rawDebug('flushSync started')
@@ -482,7 +494,8 @@ function flushSync (stream) {
     const readIndex = Atomics.load(stream[kImpl].state, READ_INDEX)
 
     if (readIndex === -2) {
-      throw new Error('_flushSync failed')
+      destroy(stream, new Error('_flushSync failed'))
+      return
     }
 
     // process._rawDebug(`(flushSync) readIndex (${readIndex}) writeIndex (${writeIndex})`)
@@ -494,7 +507,8 @@ function flushSync (stream) {
     }
 
     if (++spins === 10) {
-      throw new Error('_flushSync took too long (10s)')
+      destroy(stream, new Error('_flushSync took too long (10s)'))
+      return
     }
   }
   // process._rawDebug('flushSync finished')

--- a/index.js
+++ b/index.js
@@ -447,8 +447,7 @@ function writeSync (stream) {
       continue
     } else if (leftover < 0) {
       // stream should never happen
-      destroy(stream, new Error('overwritten'))
-      return
+      throw new Error('overwritten')
     }
 
     let toWrite = stream[kImpl].buf.slice(0, leftover)
@@ -479,8 +478,7 @@ function writeSync (stream) {
 
 function flushSync (stream) {
   if (stream[kImpl].flushing) {
-    destroy(stream, new Error('unable to flush while flushing'))
-    return
+    throw new Error('unable to flush while flushing')
   }
 
   // process._rawDebug('flushSync started')
@@ -494,8 +492,7 @@ function flushSync (stream) {
     const readIndex = Atomics.load(stream[kImpl].state, READ_INDEX)
 
     if (readIndex === -2) {
-      destroy(stream, new Error('_flushSync failed'))
-      return
+      throw Error('_flushSync failed')
     }
 
     // process._rawDebug(`(flushSync) readIndex (${readIndex}) writeIndex (${writeIndex})`)
@@ -507,8 +504,7 @@ function flushSync (stream) {
     }
 
     if (++spins === 10) {
-      destroy(stream, new Error('_flushSync took too long (10s)'))
-      return
+      throw new Error('_flushSync took too long (10s)')
     }
   }
   // process._rawDebug('flushSync finished')

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -263,7 +263,7 @@ test('destroy does not error', function (t) {
   })
 
   stream.on('error', (err) => {
-    t.equal(err.message, 'The worker thread exited')
+    t.equal(err.message, 'the worker thread exited')
     stream.flush((err) => {
       t.equal(err.message, 'the worker has exited')
     })

--- a/test/thread-management.test.js
+++ b/test/thread-management.test.js
@@ -29,50 +29,16 @@ test('emit error if thread exits', async function (t) {
     stream.write('hello world\n')
   })
 
-  const [err] = await once(stream, 'error')
-  t.equal(err.message, 'The worker thread exited')
+  let [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker thread exited')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
-})
-
-test('emit error if thread exits', async function (t) {
-  const stream = new ThreadStream({
-    filename: join(__dirname, 'exit.js'),
-    sync: true
-  })
-
-  stream.on('ready', () => {
-    stream.write('hello world\n')
-  })
-
-  const [err] = await once(stream, 'error')
-  t.equal(err.message, 'The worker thread exited')
-
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
-
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 })
 
 test('emit error if thread have unhandledRejection', async function (t) {
@@ -85,22 +51,16 @@ test('emit error if thread have unhandledRejection', async function (t) {
     stream.write('hello world\n')
   })
 
-  const [err] = await once(stream, 'error')
+  let [err] = await once(stream, 'error')
   t.equal(err.message, 'kaboom')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 })
 
 test('emit error if worker stream emit error', async function (t) {
@@ -113,22 +73,16 @@ test('emit error if worker stream emit error', async function (t) {
     stream.write('hello world\n')
   })
 
-  const [err] = await once(stream, 'error')
+  let [err] = await once(stream, 'error')
   t.equal(err.message, 'kaboom')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 })
 
 test('emit error if thread have uncaughtException', async function (t) {
@@ -141,22 +95,16 @@ test('emit error if thread have uncaughtException', async function (t) {
     stream.write('hello world\n')
   })
 
-  const [err] = await once(stream, 'error')
+  let [err] = await once(stream, 'error')
   t.equal(err.message, 'kaboom')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 
-  try {
-    stream.write('noop')
-    t.fail('unreacheable')
-  } catch (err) {
-    t.equal(err.message, 'the worker has exited')
-  }
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  t.equal(err.message, 'the worker has exited')
 })
 
 test('close the work if out of scope on gc', { skip: !global.WeakRef }, async function (t) {


### PR DESCRIPTION
Since multistream is calling stream.write(data) without a try/catch we should not throw errors but emit errors (to let users decide what to do).

Reference: https://github.com/pinojs/pino/issues/1489