### PR TITLE
Ensure DOM lib is available for type Transferable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference lib="DOM" />
 import { EventEmitter } from 'events'
 import * as workerThreads from 'worker_threads'
 


### PR DESCRIPTION
In certain environments, index.d.ts will generate a typing error when thread-stream is included a dependency of pino, and TS config (skipLibCheck) is not set to true.

**Before:**
```bash
$ [other-package] > npx tsc

TS2304: Cannot find name 'Transferable'.

89   emit(eventName: 'message', message: any, transferList?: Transferable[]): boolean
                                                             ~~~~~~~~~~~~
Found 1 error in ../../../../thread-stream/index.d.ts:90
```

After:
```bash
$ [other-package] > npx tsc
```

Adding the reference makes the compiler aware of the reference to the library, even if the package consuming it, does not have the necessary types included.