### PR TITLE
Add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "description": "A streaming way to send data to a Node.js Worker Thread",
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib/",
+    "LICENSE",
+    "README.md"
+  ],
   "dependencies": {
     "real-require": "^0.2.0"
   },


### PR DESCRIPTION
I noticed that the `thread-stream` package gets installed with test files and other various dev files that don't need to be there. This came to our attention when a custom crawler came across the `syntax-error.mjs` file in the `test` directory. We modified our crawler to get around it, but I figured it might be helpful to tighten up the published assets here too. Isolating the published package to specific files will reduce the package size for everyone.