### PR TITLE
chore: upgrade to typescript v6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pino-elasticsearch": "^8.0.0",
     "sonic-boom": "^5.0.0",
     "ts-node": "^10.8.0",
-    "typescript": "~5.7.3"
+    "typescript": "~6.0.2"
   },
   "scripts": {
     "build": "tsc --noEmit",

--- a/test/transpiled.test.js
+++ b/test/transpiled.test.js
@@ -23,7 +23,6 @@ function basic (esVersion) {
   })
 }
 
-basic('es5')
 basic('es6')
 basic('es2017')
 basic('esnext')

--- a/test/ts/transpile.sh
+++ b/test/ts/transpile.sh
@@ -10,10 +10,9 @@ else
   export RUNNER="npx";
 fi
 
-test ./to-file.ts -ot ./to-file.es5.cjs    || ("${RUNNER}" tsc --skipLibCheck --target es5                      ./to-file.ts && mv ./to-file.js ./to-file.es5.cjs);
-test ./to-file.ts -ot ./to-file.es6.mjs    || ("${RUNNER}" tsc --skipLibCheck --target es6                      ./to-file.ts && mv ./to-file.js ./to-file.es6.mjs);
-test ./to-file.ts -ot ./to-file.es6.cjs    || ("${RUNNER}" tsc --skipLibCheck --target es6    --module commonjs ./to-file.ts && mv ./to-file.js ./to-file.es6.cjs);
-test ./to-file.ts -ot ./to-file.es2017.mjs || ("${RUNNER}" tsc --skipLibCheck --target es2017                   ./to-file.ts && mv ./to-file.js ./to-file.es2017.mjs);
-test ./to-file.ts -ot ./to-file.es2017.cjs || ("${RUNNER}" tsc --skipLibCheck --target es2017 --module commonjs ./to-file.ts && mv ./to-file.js ./to-file.es2017.cjs);
-test ./to-file.ts -ot ./to-file.esnext.mjs || ("${RUNNER}" tsc --skipLibCheck --target esnext --module esnext   ./to-file.ts && mv ./to-file.js ./to-file.esnext.mjs);
-test ./to-file.ts -ot ./to-file.esnext.cjs || ("${RUNNER}" tsc --skipLibCheck --target esnext --module commonjs ./to-file.ts && mv ./to-file.js ./to-file.esnext.cjs);
+test ./to-file.ts -ot ./to-file.es6.mjs    || ("${RUNNER}" tsc --ignoreConfig --skipLibCheck --types node --target es6                      ./to-file.ts && mv ./to-file.js ./to-file.es6.mjs);
+test ./to-file.ts -ot ./to-file.es6.cjs    || ("${RUNNER}" tsc --ignoreConfig --skipLibCheck --types node --target es6    --module commonjs ./to-file.ts && mv ./to-file.js ./to-file.es6.cjs);
+test ./to-file.ts -ot ./to-file.es2017.mjs || ("${RUNNER}" tsc --ignoreConfig --skipLibCheck --types node --target es2017                   ./to-file.ts && mv ./to-file.js ./to-file.es2017.mjs);
+test ./to-file.ts -ot ./to-file.es2017.cjs || ("${RUNNER}" tsc --ignoreConfig --skipLibCheck --types node --target es2017 --module commonjs ./to-file.ts && mv ./to-file.js ./to-file.es2017.cjs);
+test ./to-file.ts -ot ./to-file.esnext.mjs || ("${RUNNER}" tsc --ignoreConfig --skipLibCheck --types node --target esnext --module esnext   ./to-file.ts && mv ./to-file.js ./to-file.esnext.mjs);
+test ./to-file.ts -ot ./to-file.esnext.cjs || ("${RUNNER}" tsc --ignoreConfig --skipLibCheck --types node --target esnext --module commonjs ./to-file.ts && mv ./to-file.js ./to-file.esnext.cjs);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
-    "compilerOptions": {
-        "esModuleInterop": true
-    },
-    "files": [
-        "index.d.ts"
-    ],
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "files": ["index.d.ts"]
 }


### PR DESCRIPTION
Proposal:

Upgrade TypeScript to v6.0.2

Changes made:

- Bump typescript from `~5.7.3` to `~6.0.2`
- Add `"types": ["node"]` to `tsconfig` compilerOptions
- Drop `es5` target from transpile tests (no longer supported in TS6)
- Add `--ignoreConfig` and `--types` node flags to `transpile.sh` test commands

