### PR TITLE
chore(package): restrict published files to runtime artifacts (#190)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "A streaming way to send data to a Node.js Worker Thread",
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib/"
+  ],
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
Closes #190.

The published tarball currently ships dev-only files (tests, \`.github/\` workflows, \`eslint.config.js\`, \`tsconfig.json\`, \`bench.js\`, the \`test/ts/transpile.sh\` scripts, etc.) because \`package.json\` has no \`files\` field and relies on the npm default excludelist.

**Before** (\`npm pack --dry-run\` on \`main\`)
\`\`\`
npm notice total files: 61
npm notice package size: 20.2 kB
npm notice unpacked size: 81.1 kB
\`\`\`

**After**
\`\`\`
LICENSE
README.md
index.d.ts
index.js
lib/indexes.js
lib/wait.js
lib/worker.js
package.json
npm notice total files: 8
npm notice package size: 9.9 kB
npm notice unpacked size: 34.7 kB
\`\`\`

Added an explicit \`files\` allowlist covering the runtime entrypoints (\`index.js\`, \`index.d.ts\`, \`lib/\`). \`LICENSE\`, \`README.md\`, and \`package.json\` are always included by npm. This also makes the published contents independent of the working tree at publish time, so stray \`.husky\` / IDE / editor swap files can no longer leak into the tarball regardless of what's on disk.

Full \`npm test\` suite: 50 passing / 3 pre-existing skipped, unchanged by this PR.