### PR TITLE
add worker loader to allow worker to be found after bundling

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const { version } = require('./package.json')
 const { EventEmitter } = require('events')
 const { Worker } = require('worker_threads')
-const { join } = require('path')
 const { pathToFileURL } = require('url')
 const { wait } = require('./lib/wait')
 const {
@@ -12,6 +11,7 @@ const {
 } = require('./lib/indexes')
 const buffer = require('buffer')
 const assert = require('assert')
+const { getWorkerPath } = require('./lib/workerLoader')
 
 const kImpl = Symbol('kImpl')
 
@@ -52,7 +52,7 @@ function createWorker (stream, opts) {
   const { filename, workerData } = opts
 
   const bundlerOverrides = '__bundlerPathsOverrides' in globalThis ? globalThis.__bundlerPathsOverrides : {}
-  const toExecute = bundlerOverrides['thread-stream-worker'] || join(__dirname, 'lib', 'worker.js')
+  const toExecute = bundlerOverrides['thread-stream-worker'] || getWorkerPath()
 
   const worker = new Worker(toExecute, {
     ...opts.workerOpts,

--- a/lib/workerLoader.js
+++ b/lib/workerLoader.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { isMainThread } = require('worker_threads')
 
 // Only runs when spawned as a Worker

--- a/lib/workerLoader.js
+++ b/lib/workerLoader.js
@@ -1,0 +1,10 @@
+const { isMainThread } = require('worker_threads')
+
+// Only runs when spawned as a Worker
+if (!isMainThread) require('./worker.js')
+
+function getWorkerPath () {
+  return __filename
+}
+
+module.exports = { getWorkerPath }


### PR DESCRIPTION
re https://github.com/pinojs/pino/issues/2272, allow thread-stream to be bundled, while still allowing the thread to be initialized by path.

As most bundlers code-split on dynamic import, this can be further enhanced when the project moves to ESM.