### PR TITLE
fix: ignore watch mode worker messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [20, 22, 24, 26]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ This module works with `yarn` in PnP (plug'n play) mode too!
 ### Emit events
 
 You can emit events on the ThreadStream from your worker using [`worker.parentPort.postMessage()`](https://nodejs.org/api/worker_threads.html#workerparentport).
-The message (JSON object) must have the following data structure:
+Messages that do not carry a thread-stream protocol `code` are ignored.
+For custom events, the message (JSON object) must have the following data structure:
 
 ```js
 parentPort.postMessage({

--- a/index.js
+++ b/index.js
@@ -163,6 +163,12 @@ function onWorkerMessage (msg) {
     return
   }
 
+  // Node.js watch mode may send internal worker messages that do not
+  // participate in thread-stream's worker protocol.
+  if (msg?.code === undefined) {
+    return
+  }
+
   switch (msg.code) {
     case 'READY':
       // Replace the FakeWeakRef with a

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ function onWorkerMessage (msg) {
 
   // Node.js watch mode may send internal worker messages that do not
   // participate in thread-stream's worker protocol.
-  if (msg?.code === undefined) {
+  if (msg?.code == null) {
     return
   }
 

--- a/test/message-without-code.js
+++ b/test/message-without-code.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { Writable } = require('stream')
+const { parentPort } = require('worker_threads')
+
+async function run () {
+  parentPort.postMessage({
+    internal: 'watch-mode'
+  })
+
+  return new Writable({
+    autoDestroy: true,
+    write (chunk, enc, cb) {
+      cb()
+    }
+  })
+}
+
+module.exports = run

--- a/test/watch-mode.test.js
+++ b/test/watch-mode.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { once } = require('events')
+const { join } = require('path')
+const ThreadStream = require('..')
+
+test('ignores worker messages without a protocol code', async function () {
+  const stream = new ThreadStream({
+    filename: join(__dirname, 'message-without-code.js'),
+    sync: false
+  })
+
+  const errors = []
+  stream.on('error', err => {
+    errors.push(err)
+  })
+
+  const ready = once(stream, 'ready')
+  const close = once(stream, 'close')
+
+  assert.ok(stream.write('hello world\n'))
+  stream.end()
+
+  await ready
+  await close
+
+  assert.deepStrictEqual(errors, [])
+})


### PR DESCRIPTION
## Summary
- ignore worker messages that do not include a thread-stream protocol `code`
- add a regression test covering a worker message without `code`
- add Node.js 26 to the CI matrix

## Testing
- npm test

Fixes #212.
