### PR TITLE
fix: check if destroyed before flushing

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,6 @@ function nextFlush (stream) {
   while (true) {
     const writeIndex = Atomics.load(stream[kImpl].state, WRITE_INDEX)
     if (stream.destroyed) {
-      error(stream, new Error('the worker has exited'))
       return
     }
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function nextFlush (stream) {
     const writeIndex = Atomics.load(stream[kImpl].state, WRITE_INDEX)
     if (stream.destroyed) {
       error(this, new Error('the worker has exited'))
-      return false
+      return
     }
 
     const leftover = stream[kImpl].data.length - writeIndex

--- a/index.js
+++ b/index.js
@@ -110,6 +110,11 @@ function drain (stream) {
 function nextFlush (stream) {
   while (true) {
     const writeIndex = Atomics.load(stream[kImpl].state, WRITE_INDEX)
+    if (stream.destroyed) {
+      error(this, new Error('the worker has exited'))
+      return false
+    }
+
     const leftover = stream[kImpl].data.length - writeIndex
 
     if (leftover > 0) {

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function nextFlush (stream) {
   while (true) {
     const writeIndex = Atomics.load(stream[kImpl].state, WRITE_INDEX)
     if (stream.destroyed) {
-      error(this, new Error('the worker has exited'))
+      error(stream, new Error('the worker has exited'))
       return
     }
 

--- a/test/error-flush.test.js
+++ b/test/error-flush.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { once } = require('node:events')
+const { join } = require('path')
+const { WRITE_INDEX } = require('../lib/indexes')
+const ThreadStream = require('..')
+
+test('emit error if worker stream emit error (async mode)', async function (t) {
+  const stream = new ThreadStream({
+    filename: join(__dirname, 'error.js'),
+    sync: false
+  })
+
+  const closed = once(stream, 'close').catch(() => {})
+  stream.on('error', () => {})
+
+  await once(stream, 'ready')
+  stream.write('hello world\n')
+
+  let [err] = await once(stream, 'error')
+  assert.strictEqual(err.message, 'kaboom')
+
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  assert.strictEqual(err.message, 'the worker has exited')
+
+  stream.write('noop');
+  [err] = await once(stream, 'error')
+  assert.strictEqual(err.message, 'the worker has exited')
+
+  await closed
+})
+
+test('nextFlush does not crash when worker errors before flush', async function (t) {
+  const stream = new ThreadStream({
+    filename: join(__dirname, 'error-immediate.js'),
+    sync: false
+  })
+
+  const closed = once(stream, 'close').catch(() => {})
+  stream.on('error', () => {})
+
+  await once(stream, 'ready')
+
+  // Block the event loop
+  const int32 = new Int32Array(new SharedArrayBuffer(WRITE_INDEX))
+  Atomics.wait(int32, 0, 0, 50)
+
+  // stream.destroyed is still false (ERROR not yet processed).
+  // Writing triggers setImmediate(nextFlush, this).
+  stream.write('data')
+
+  // The event loop then processes pending messages before the
+  // check phase:
+  // 1. ERROR message → destroy → stream.destroyed = true
+  // 2. check phase: nextFlush runs → loads WRITE_INDEX = -2
+
+  await closed
+})

--- a/test/error-immediate.js
+++ b/test/error-immediate.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { EventEmitter } = require('events')
+
+async function run (opts) {
+  const dest = new EventEmitter()
+  dest.write = function () { return true }
+  dest.end = function () { dest.emit('close') }
+
+  setTimeout(() => {
+    dest.emit('error', new Error('kaboom'))
+  }, 50)
+
+  return dest
+}
+
+module.exports = run


### PR DESCRIPTION
Bug: `ERR_OUT_OF_RANGE` when worker errors while main thread is blocked

When a `'ERROR'` is posted. The shared memory has written `-2` and notify atomically, then `ThreadStream` class `write (data)` method gets called after the `onWorkerMessage` function gets called then calls the `destroy` method. So when `nextFlush` is entered in the next phase, it will throw error:

```bash
node:buffer:247
      throw new ERR_OUT_OF_RANGE('targetStart', '>= 0', targetStart);
      ^

RangeError [ERR_OUT_OF_RANGE]: The value of "targetStart" is out of range. It must be >= 0. Received -2
    at copyImpl (node:buffer:247:13)
    at Buffer.copy (node:buffer:901:12)
    at write (/home/alston/Programming/pino-debug/node_modules/thread-stream/index.js:510:11)
    at Immediate.nextFlush (/home/alston/Programming/pino-debug/node_modules/thread-stream/index.js:128:7)
    at process.processImmediate (node:internal/timers:506:21)
    at process.callbackTrampoline (node:internal/async_hooks:130:17) {
  code: 'ERR_OUT_OF_RANGE'
}

Node.js v24.15.0
```

This is the script I used to simulate the error. Somehow I can only simulate this error when I busy block the main thread, because I get this error in my fastify server when packaged in docker, where I use non-root user to attempt to mkdir, but instead of getting permission error I get that out of range error.

```javascript
import pino from "pino"
import { mkdirSync, rmSync } from "node:fs"
import { dirname, join } from "node:path"

// Ensure directory does NOT exist so SonicBoom gets ENOENT
const logDir = join(dirname(import.meta.url), "logs")
try { rmSync(logDir, { recursive: true, force: true }) } catch {}
const transport = pino.transport({
  target: "pino-roll",
  options: { file: "./logs/server.log", frequency: "daily" },
})

const logger = pino({}, transport)
// Busy loop main thread
const end = Date.now() + 5000
while (Date.now() < end) {}
logger.info("trigger")  
setInterval(() => {}, 60_000)
```

I simply added a `stream.destroyed` guard at the top of the `nextFlush` loop, after loading `WRITE_INDEX`