### PR TITLE
v3: backport #213 (ignore Node --watch worker messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ This module works with `yarn` in PnP (plug'n play) mode too!
 ### Emit events
 
 You can emit events on the ThreadStream from your worker using [`worker.parentPort.postMessage()`](https://nodejs.org/api/worker_threads.html#workerparentport).
-The message (JSON object) must have the following data structure:
+Messages that do not carry a thread-stream protocol `code` are ignored.
+For custom events, the message (JSON object) must have the following data structure:
 
 ```js
 parentPort.postMessage({

--- a/index.js
+++ b/index.js
@@ -160,6 +160,12 @@ function onWorkerMessage (msg) {
     return
   }
 
+  // Node.js watch mode may send internal worker messages that do not
+  // participate in thread-stream's worker protocol.
+  if (msg?.code == null) {
+    return
+  }
+
   switch (msg.code) {
     case 'READY':
       // Replace the FakeWeakRef with a

--- a/test/message-without-code.js
+++ b/test/message-without-code.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { Writable } = require('stream')
+const { parentPort } = require('worker_threads')
+
+async function run () {
+  parentPort.postMessage({
+    internal: 'watch-mode'
+  })
+
+  return new Writable({
+    autoDestroy: true,
+    write (chunk, enc, cb) {
+      cb()
+    }
+  })
+}
+
+module.exports = run

--- a/test/watch-mode.test.js
+++ b/test/watch-mode.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const { test } = require('tap')
+const { join } = require('path')
+const { once } = require('events')
+const ThreadStream = require('..')
+
+test('ignores worker messages without a protocol code', async function (t) {
+  const stream = new ThreadStream({
+    filename: join(__dirname, 'message-without-code.js'),
+    sync: false
+  })
+
+  const errors = []
+  stream.on('error', err => {
+    errors.push(err)
+  })
+
+  const ready = once(stream, 'ready')
+  const close = once(stream, 'close')
+
+  t.ok(stream.write('hello world\n'))
+  stream.end()
+
+  await ready
+  await close
+
+  t.same(errors, [])
+})


### PR DESCRIPTION
Heads up before reviewing: this PR is built on top of `v3.1.0`, not on `main`. GitHub's diff against `main` will look noisy because the 4.x line moved on. The actual change is the single commit a177143 — feel free to cherry-pick it onto a `v3.x` maintenance branch and close this PR.

Backports #213 to the 3.x line. Same one-liner in `onWorkerMessage` plus the regression test, just expressed with `tap` to match how v3 tests are written.

## Why

Node 24.16 shipped on 2026-05-21 with the backport of nodejs/node#62368 (`watch: track worker entry files in --watch mode`). Once `--watch` is active, the runtime starts sending tracking messages over `parentPort` without the protocol `code` field thread-stream looks for. The default branch in the switch then throws `Error: this should not happen: undefined` and kills the process on the first tick.

This is the exact case #212 reported on Node 26 and #213 fixed in 4.1.0. The 3.x line never picked the fix — last release on that branch is `3.1.0` from June 2024 — so anyone still on `pino@9` (which pins `thread-stream: ^3.0.0`) breaks on a fresh install the moment they upgrade Node. `pino-pretty` bumps don't help because the dep flows through pino itself.

Full incident write-up is in #220 with timeline and repro.

## What's in the diff

- `index.js`: bail out early when the message has no `code`, before hitting the `switch`.
- `test/watch-mode.test.js` + `test/message-without-code.js`: the regression test from #213, ported to `tap` (the v3 line still uses `tap`, not `node:test`).
- `README.md`: short note that messages without a `code` are ignored, so people writing custom worker events aren't confused.

CI workflow is intentionally untouched — didn't want to widen the scope.

## Test

```
$ ./node_modules/.bin/tap test/watch-mode.test.js
TAP version 13
ok 1 - test/watch-mode.test.js # time=181ms
```

Full suite was a bit flaky locally on unrelated tests, same as I see on green CI runs for `main`, so I limited my run to the new test plus `base.test.js`, both green.

## Workaround in the meantime

For anyone landing here from Google: `pnpm.overrides` (or npm `overrides`) forcing `thread-stream: ^4.0.0` works. But that's not exactly something users would guess from the stack trace alone, which is the motivation for cutting a 3.x patch.

Refs #220.