### PR TITLE
fix: ignore watch mode worker messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ This module works with `yarn` in PnP (plug'n play) mode too!
 ### Emit events
 
 You can emit events on the ThreadStream from your worker using [`worker.parentPort.postMessage()`](https://nodejs.org/api/worker_threads.html#workerparentport).
-The message (JSON object) must have the following data structure:
+Messages that do not carry a thread-stream protocol `code` are ignored.
+For custom events, the message (JSON object) must have the following data structure:
 
 ```js
 parentPort.postMessage({

--- a/index.js
+++ b/index.js
@@ -174,6 +174,12 @@ function onWorkerMessage (msg) {
     return
   }
 
+  // Node.js watch mode may send internal worker messages that do not
+  // participate in thread-stream's worker protocol.
+  if (msg?.code == null) {
+    return
+  }
+
   switch (msg.code) {
     case 'READY':
       // Replace the FakeWeakRef with a

--- a/test/message-without-code.js
+++ b/test/message-without-code.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { Writable } = require('stream')
+const { parentPort } = require('worker_threads')
+
+async function run () {
+  parentPort.postMessage({
+    internal: 'watch-mode'
+  })
+
+  return new Writable({
+    autoDestroy: true,
+    write (chunk, enc, cb) {
+      cb()
+    }
+  })
+}
+
+module.exports = run

--- a/test/watch-mode.test.js
+++ b/test/watch-mode.test.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const { test } = require('tap')
-const { once } = require('events')
 const { join } = require('path')
 const ThreadStream = require('..')
 
-test('ignores worker messages without a protocol code', async function (t) {
+test('ignores worker messages without a protocol code', function (t) {
+  t.plan(2)
+
   const stream = new ThreadStream({
     filename: join(__dirname, 'message-without-code.js'),
     sync: false
@@ -16,14 +17,12 @@ test('ignores worker messages without a protocol code', async function (t) {
     errors.push(err)
   })
 
-  const ready = once(stream, 'ready')
-  const close = once(stream, 'close')
+  stream.on('ready', () => {
+    t.ok(stream.write('hello world\n'))
+    stream.end()
+  })
 
-  t.ok(stream.write('hello world\n'))
-  stream.end()
-
-  await ready
-  await close
-
-  t.same(errors, [])
+  stream.on('finish', () => {
+    t.same(errors, [])
+  })
 })

--- a/test/watch-mode.test.js
+++ b/test/watch-mode.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const { test } = require('tap')
+const { once } = require('events')
+const { join } = require('path')
+const ThreadStream = require('..')
+
+test('ignores worker messages without a protocol code', async function (t) {
+  const stream = new ThreadStream({
+    filename: join(__dirname, 'message-without-code.js'),
+    sync: false
+  })
+
+  const errors = []
+  stream.on('error', err => {
+    errors.push(err)
+  })
+
+  const ready = once(stream, 'ready')
+  const close = once(stream, 'close')
+
+  t.ok(stream.write('hello world\n'))
+  stream.end()
+
+  await ready
+  await close
+
+  t.same(errors, [])
+})


### PR DESCRIPTION
## Summary
- backport the watch mode worker message guard from #213 onto the `v3.x` line
- ignore worker messages that do not include a thread-stream protocol `code`
- add a regression test covering a worker message without `code`
- document that non-protocol worker messages are ignored

## Testing
- npm test

Fixes #220.
