### PR TITLE
fix: stabilize v3.x base tests and buffer wraparound

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ const { pathToFileURL } = require('url')
 const { wait } = require('./lib/wait')
 const {
   WRITE_INDEX,
-  READ_INDEX
+  READ_INDEX,
+  SEQ_INDEX
 } = require('./lib/indexes')
 const buffer = require('buffer')
 const assert = require('assert')
@@ -17,6 +18,13 @@ const kImpl = Symbol('kImpl')
 
 // V8 limit for string size
 const MAX_STRING = buffer.constants.MAX_STRING_LENGTH
+
+function updateState (stream, fn) {
+  Atomics.add(stream[kImpl].state, SEQ_INDEX, 1)
+  fn()
+  Atomics.add(stream[kImpl].state, SEQ_INDEX, 1)
+  Atomics.notify(stream[kImpl].state, SEQ_INDEX)
+}
 
 class FakeWeakRef {
   constructor (value) {
@@ -120,8 +128,11 @@ function nextFlush (stream) {
           return
         }
 
-        Atomics.store(stream[kImpl].state, READ_INDEX, 0)
-        Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+        updateState(stream, () => {
+          Atomics.store(stream[kImpl].state, READ_INDEX, 0)
+          Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+        })
+        Atomics.notify(stream[kImpl].state, READ_INDEX)
 
         // Find a toWrite length that fits the buffer
         // it must exists as the buffer is at least 4 bytes length
@@ -141,8 +152,11 @@ function nextFlush (stream) {
       return
     }
     stream.flush(() => {
-      Atomics.store(stream[kImpl].state, READ_INDEX, 0)
-      Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+      updateState(stream, () => {
+        Atomics.store(stream[kImpl].state, READ_INDEX, 0)
+        Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+      })
+      Atomics.notify(stream[kImpl].state, READ_INDEX)
       nextFlush(stream)
     })
   } else {
@@ -401,8 +415,9 @@ function write (stream, data, cb) {
   const current = Atomics.load(stream[kImpl].state, WRITE_INDEX)
   const length = Buffer.byteLength(data)
   stream[kImpl].data.write(data, current)
-  Atomics.store(stream[kImpl].state, WRITE_INDEX, current + length)
-  Atomics.notify(stream[kImpl].state, WRITE_INDEX)
+  updateState(stream, () => {
+    Atomics.store(stream[kImpl].state, WRITE_INDEX, current + length)
+  })
   cb()
   return true
 }
@@ -419,9 +434,10 @@ function end (stream) {
     let readIndex = Atomics.load(stream[kImpl].state, READ_INDEX)
 
     // process._rawDebug('writing index')
-    Atomics.store(stream[kImpl].state, WRITE_INDEX, -1)
+    updateState(stream, () => {
+      Atomics.store(stream[kImpl].state, WRITE_INDEX, -1)
+    })
     // process._rawDebug(`(end) readIndex (${Atomics.load(stream.state, READ_INDEX)}) writeIndex (${Atomics.load(stream.state, WRITE_INDEX)})`)
-    Atomics.notify(stream[kImpl].state, WRITE_INDEX)
 
     // Wait for the process to complete
     let spins = 0
@@ -466,8 +482,11 @@ function writeSync (stream) {
     let leftover = stream[kImpl].data.length - writeIndex
     if (leftover === 0) {
       flushSync(stream)
-      Atomics.store(stream[kImpl].state, READ_INDEX, 0)
-      Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+      updateState(stream, () => {
+        Atomics.store(stream[kImpl].state, READ_INDEX, 0)
+        Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+      })
+      Atomics.notify(stream[kImpl].state, READ_INDEX)
       continue
     } else if (leftover < 0) {
       // stream should never happen
@@ -483,8 +502,11 @@ function writeSync (stream) {
     } else {
       // multi-byte utf-8
       flushSync(stream)
-      Atomics.store(stream[kImpl].state, READ_INDEX, 0)
-      Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+      updateState(stream, () => {
+        Atomics.store(stream[kImpl].state, READ_INDEX, 0)
+        Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
+      })
+      Atomics.notify(stream[kImpl].state, READ_INDEX)
 
       // Find a toWrite length that fits the buffer
       // it must exists as the buffer is at least 4 bytes length

--- a/lib/indexes.js
+++ b/lib/indexes.js
@@ -1,9 +1,11 @@
 'use strict'
 
+const SEQ_INDEX = 2
 const WRITE_INDEX = 4
 const READ_INDEX = 8
 
 module.exports = {
   WRITE_INDEX,
-  READ_INDEX
+  READ_INDEX,
+  SEQ_INDEX
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,7 +2,7 @@
 
 const { realImport, realRequire } = require('real-require')
 const { workerData, parentPort } = require('worker_threads')
-const { WRITE_INDEX, READ_INDEX } = require('./indexes')
+const { WRITE_INDEX, READ_INDEX, SEQ_INDEX } = require('./indexes')
 const { waitDiff } = require('./wait')
 
 const {
@@ -101,18 +101,30 @@ start().then(function () {
   process.nextTick(run)
 })
 
+function readState () {
+  while (true) {
+    const seq = Atomics.load(state, SEQ_INDEX)
+
+    if ((seq & 1) !== 0) {
+      continue
+    }
+
+    const current = Atomics.load(state, READ_INDEX)
+    const end = Atomics.load(state, WRITE_INDEX)
+
+    if (seq === Atomics.load(state, SEQ_INDEX)) {
+      return { current, end, seq }
+    }
+  }
+}
+
 function run () {
-  const current = Atomics.load(state, READ_INDEX)
-  const end = Atomics.load(state, WRITE_INDEX)
+  const { current, end, seq } = readState()
 
   // process._rawDebug(`pre state ${current} ${end}`)
 
   if (end === current) {
-    if (end === data.length) {
-      waitDiff(state, READ_INDEX, end, Infinity, run)
-    } else {
-      waitDiff(state, WRITE_INDEX, end, Infinity, run)
-    }
+    waitDiff(state, SEQ_INDEX, seq, Infinity, run)
     return
   }
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -175,7 +175,7 @@ test('over the bufferSize at startup (async)', function (t, done) {
   })
 })
 
-test('flushSync sync=false', function (t, done) {
+test('flushSync sync=false', async function () {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 128,
@@ -184,22 +184,30 @@ test('flushSync sync=false', function (t, done) {
     sync: false
   })
 
+  const close = once(stream, 'close')
+
   stream.on('drain', () => {
     stream.end()
-  })
-
-  stream.on('close', () => {
-    readFile(dest, 'utf8', (err, data) => {
-      assert.ifError(err)
-      assert.strictEqual(data.length, 200)
-      done()
-    })
   })
 
   for (let count = 0; count < 20; count++) {
     stream.write('aaaaaaaaaa')
   }
   stream.flushSync()
+
+  await close
+
+  const data = await new Promise((resolve, reject) => {
+    readFile(dest, 'utf8', (err, data) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(data)
+    })
+  })
+
+  assert.strictEqual(data.length, 200)
 })
 
 test('pass down MessagePorts', async function (t) {
@@ -224,7 +232,7 @@ test('pass down MessagePorts', async function (t) {
   assert.strictEqual(strings, 'hello world\nsomething else\n')
 })
 
-test('destroy does not error', function (t, done) {
+test('destroy does not error', async function () {
   const dest = file()
   const stream = new ThreadStream({
     filename: join(__dirname, 'to-file.js'),
@@ -236,24 +244,25 @@ test('destroy does not error', function (t, done) {
     stream.worker.terminate()
   })
 
-  stream.on('error', (err) => {
-    assert.strictEqual(err.message, 'the worker thread exited')
+  const [err] = await once(stream, 'error')
+  assert.strictEqual(err.message, 'the worker thread exited')
+
+  await new Promise((resolve) => {
     stream.flush((err) => {
       assert.strictEqual(err.message, 'the worker has exited')
+      resolve()
     })
-    assert.doesNotThrow(() => stream.flushSync())
-    assert.doesNotThrow(() => stream.end())
-    done()
   })
+
+  assert.doesNotThrow(() => stream.flushSync())
+  assert.doesNotThrow(() => stream.end())
 })
 
-test('syntax error', function (t, done) {
+test('syntax error', async function () {
   const stream = new ThreadStream({
     filename: join(__dirname, 'syntax-error.mjs')
   })
 
-  stream.on('error', (err) => {
-    assert.strictEqual(err.message, 'Unexpected end of input')
-    done()
-  })
+  const [err] = await once(stream, 'error')
+  assert.strictEqual(err.message, 'Unexpected end of input')
 })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -9,7 +9,19 @@ const ThreadStream = require('..')
 const { MessageChannel } = require('worker_threads')
 const { once } = require('events')
 
-test('base sync=true', function (t, done) {
+function readFileAsync (path) {
+  return new Promise((resolve, reject) => {
+    readFile(path, 'utf8', (err, data) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(data)
+    })
+  })
+}
+
+test('base sync=true', async function () {
   const dest = file()
   const stream = new ThreadStream({
     filename: join(__dirname, 'to-file.js'),
@@ -17,24 +29,12 @@ test('base sync=true', function (t, done) {
     sync: true
   })
 
+  const finish = once(stream, 'finish')
+  const close = once(stream, 'close')
+
   assert.deepStrictEqual(stream.writableObjectMode, false)
-
   assert.deepStrictEqual(stream.writableFinished, false)
-  stream.on('finish', () => {
-    assert.deepStrictEqual(stream.writableFinished, true)
-    readFile(dest, 'utf8', (err, data) => {
-      assert.ifError(err)
-      assert.strictEqual(data, 'hello world\nsomething else\n')
-    })
-  })
-
   assert.deepStrictEqual(stream.closed, false)
-  stream.on('close', () => {
-    assert.deepStrictEqual(stream.closed, true)
-    assert.ok(!stream.writable)
-    done()
-  })
-
   assert.deepStrictEqual(stream.writableNeedDrain, false)
   assert.ok(stream.write('hello world\n'))
   assert.ok(stream.write('something else\n'))
@@ -43,9 +43,19 @@ test('base sync=true', function (t, done) {
   assert.deepStrictEqual(stream.writableEnded, false)
   stream.end()
   assert.deepStrictEqual(stream.writableEnded, true)
+
+  await finish
+  assert.deepStrictEqual(stream.writableFinished, true)
+
+  await close
+  assert.deepStrictEqual(stream.closed, true)
+  assert.ok(!stream.writable)
+
+  const data = await readFileAsync(dest)
+  assert.strictEqual(data, 'hello world\nsomething else\n')
 })
 
-test('overflow sync=true', function (t, done) {
+test('overflow sync=true', async function () {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 128,
@@ -54,9 +64,9 @@ test('overflow sync=true', function (t, done) {
     sync: true
   })
 
+  const close = once(stream, 'close')
   let count = 0
 
-  // Write 10 chars, 20 times
   function write () {
     if (count++ === 20) {
       stream.end()
@@ -64,22 +74,17 @@ test('overflow sync=true', function (t, done) {
     }
 
     stream.write('aaaaaaaaaa')
-    // do not wait for drain event
     setImmediate(write)
   }
 
   write()
 
-  stream.on('close', () => {
-    readFile(dest, 'utf8', (err, data) => {
-      assert.ifError(err)
-      assert.strictEqual(data.length, 200)
-      done()
-    })
-  })
+  await close
+  const data = await readFileAsync(dest)
+  assert.strictEqual(data.length, 200)
 })
 
-test('overflow sync=false', function (t, done) {
+test('overflow sync=false', async function () {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 128,
@@ -88,11 +93,11 @@ test('overflow sync=false', function (t, done) {
     sync: false
   })
 
+  const close = once(stream, 'close')
   let count = 0
 
   assert.deepStrictEqual(stream.writableNeedDrain, false)
 
-  // Write 10 chars, 20 times
   function write () {
     if (count++ === 20) {
       stream.end()
@@ -102,7 +107,6 @@ test('overflow sync=false', function (t, done) {
     if (!stream.write('aaaaaaaaaa')) {
       assert.deepStrictEqual(stream.writableNeedDrain, true)
     }
-    // do not wait for drain event
     setImmediate(write)
   }
 
@@ -112,16 +116,12 @@ test('overflow sync=false', function (t, done) {
     assert.deepStrictEqual(stream.writableNeedDrain, false)
   })
 
-  stream.on('close', () => {
-    readFile(dest, 'utf8', (err, data) => {
-      assert.ifError(err)
-      assert.strictEqual(data.length, 200)
-      done()
-    })
-  })
+  await close
+  const data = await readFileAsync(dest)
+  assert.strictEqual(data.length, 200)
 })
 
-test('over the bufferSize at startup', function (t, done) {
+test('over the bufferSize at startup', async function () {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 10,
@@ -130,25 +130,23 @@ test('over the bufferSize at startup', function (t, done) {
     sync: true
   })
 
-  stream.on('finish', () => {
-    readFile(dest, 'utf8', (err, data) => {
-      assert.ifError(err)
-      assert.strictEqual(data, 'hello world\nsomething else\n')
-    })
-  })
-
-  stream.on('close', () => {
-    done()
-  })
+  const finish = once(stream, 'finish')
+  const close = once(stream, 'close')
 
   assert.ok(stream.write('hello'))
   assert.ok(stream.write(' world\n'))
   assert.ok(stream.write('something else\n'))
 
   stream.end()
+
+  await finish
+  await close
+
+  const data = await readFileAsync(dest)
+  assert.strictEqual(data, 'hello world\nsomething else\n')
 })
 
-test('over the bufferSize at startup (async)', function (t, done) {
+test('over the bufferSize at startup (async)', async function () {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 10,
@@ -157,22 +155,20 @@ test('over the bufferSize at startup (async)', function (t, done) {
     sync: false
   })
 
+  const finish = once(stream, 'finish')
+  const close = once(stream, 'close')
+
   assert.ok(stream.write('hello'))
   assert.ok(!stream.write(' world\n'))
   assert.ok(!stream.write('something else\n'))
 
   stream.end()
 
-  stream.on('finish', () => {
-    readFile(dest, 'utf8', (err, data) => {
-      assert.ifError(err)
-      assert.strictEqual(data, 'hello world\nsomething else\n')
-    })
-  })
+  await finish
+  await close
 
-  stream.on('close', () => {
-    done()
-  })
+  const data = await readFileAsync(dest)
+  assert.strictEqual(data, 'hello world\nsomething else\n')
 })
 
 test('flushSync sync=false', async function () {
@@ -197,16 +193,7 @@ test('flushSync sync=false', async function () {
 
   await close
 
-  const data = await new Promise((resolve, reject) => {
-    readFile(dest, 'utf8', (err, data) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve(data)
-    })
-  })
-
+  const data = await readFileAsync(dest)
   assert.strictEqual(data.length, 200)
 })
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -170,7 +170,9 @@ test('over the bufferSize at startup (async)', function (t) {
   })
 })
 
-test('flushSync sync=false', async function (t) {
+test('flushSync sync=false', function (t) {
+  t.plan(2)
+
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 128,
@@ -179,24 +181,23 @@ test('flushSync sync=false', async function (t) {
     sync: false
   })
 
-  await once(stream, 'ready')
+  stream.on('ready', () => {
+    for (let count = 0; count < 20; count++) {
+      stream.write('aaaaaaaaaa')
+    }
 
-  const finish = once(stream, 'finish')
-  const close = once(stream, 'close')
+    stream.flushSync()
+    setImmediate(() => {
+      stream.end()
+    })
+  })
 
-  for (let count = 0; count < 20; count++) {
-    stream.write('aaaaaaaaaa')
-  }
-
-  stream.flushSync()
-  await new Promise((resolve) => setImmediate(resolve))
-  stream.end()
-
-  await finish
-  await close
-
-  const data = await readFileAsync(dest)
-  t.equal(data.length, 200)
+  stream.on('finish', () => {
+    readFile(dest, 'utf8', (err, data) => {
+      t.error(err)
+      t.equal(data.length, 200)
+    })
+  })
 })
 
 test('pass down MessagePorts', async function (t) {

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
-const assert = require('node:assert')
+const { test } = require('tap')
 const { join } = require('path')
 const { readFile } = require('fs')
 const { file } = require('./helper')
@@ -21,7 +20,7 @@ function readFileAsync (path) {
   })
 }
 
-test('base sync=true', async function () {
+test('base sync=true', async function (t) {
   const dest = file()
   const stream = new ThreadStream({
     filename: join(__dirname, 'to-file.js'),
@@ -32,30 +31,30 @@ test('base sync=true', async function () {
   const finish = once(stream, 'finish')
   const close = once(stream, 'close')
 
-  assert.deepStrictEqual(stream.writableObjectMode, false)
-  assert.deepStrictEqual(stream.writableFinished, false)
-  assert.deepStrictEqual(stream.closed, false)
-  assert.deepStrictEqual(stream.writableNeedDrain, false)
-  assert.ok(stream.write('hello world\n'))
-  assert.ok(stream.write('something else\n'))
-  assert.ok(stream.writable)
+  t.same(stream.writableObjectMode, false)
+  t.same(stream.writableFinished, false)
+  t.same(stream.closed, false)
+  t.same(stream.writableNeedDrain, false)
+  t.ok(stream.write('hello world\n'))
+  t.ok(stream.write('something else\n'))
+  t.ok(stream.writable)
 
-  assert.deepStrictEqual(stream.writableEnded, false)
+  t.same(stream.writableEnded, false)
   stream.end()
-  assert.deepStrictEqual(stream.writableEnded, true)
+  t.same(stream.writableEnded, true)
 
   await finish
-  assert.deepStrictEqual(stream.writableFinished, true)
+  t.same(stream.writableFinished, true)
 
   await close
-  assert.deepStrictEqual(stream.closed, true)
-  assert.ok(!stream.writable)
+  t.same(stream.closed, true)
+  t.notOk(stream.writable)
 
   const data = await readFileAsync(dest)
-  assert.strictEqual(data, 'hello world\nsomething else\n')
+  t.equal(data, 'hello world\nsomething else\n')
 })
 
-test('overflow sync=true', async function () {
+test('overflow sync=true', async function (t) {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 128,
@@ -81,10 +80,10 @@ test('overflow sync=true', async function () {
 
   await close
   const data = await readFileAsync(dest)
-  assert.strictEqual(data.length, 200)
+  t.equal(data.length, 200)
 })
 
-test('overflow sync=false', async function () {
+test('overflow sync=false', async function (t) {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 128,
@@ -96,7 +95,7 @@ test('overflow sync=false', async function () {
   const close = once(stream, 'close')
   let count = 0
 
-  assert.deepStrictEqual(stream.writableNeedDrain, false)
+  t.same(stream.writableNeedDrain, false)
 
   function write () {
     if (count++ === 20) {
@@ -105,7 +104,7 @@ test('overflow sync=false', async function () {
     }
 
     if (!stream.write('aaaaaaaaaa')) {
-      assert.deepStrictEqual(stream.writableNeedDrain, true)
+      t.same(stream.writableNeedDrain, true)
     }
     setImmediate(write)
   }
@@ -113,15 +112,15 @@ test('overflow sync=false', async function () {
   write()
 
   stream.on('drain', () => {
-    assert.deepStrictEqual(stream.writableNeedDrain, false)
+    t.same(stream.writableNeedDrain, false)
   })
 
   await close
   const data = await readFileAsync(dest)
-  assert.strictEqual(data.length, 200)
+  t.equal(data.length, 200)
 })
 
-test('over the bufferSize at startup', async function () {
+test('over the bufferSize at startup', async function (t) {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 10,
@@ -133,9 +132,9 @@ test('over the bufferSize at startup', async function () {
   const finish = once(stream, 'finish')
   const close = once(stream, 'close')
 
-  assert.ok(stream.write('hello'))
-  assert.ok(stream.write(' world\n'))
-  assert.ok(stream.write('something else\n'))
+  t.ok(stream.write('hello'))
+  t.ok(stream.write(' world\n'))
+  t.ok(stream.write('something else\n'))
 
   stream.end()
 
@@ -143,10 +142,10 @@ test('over the bufferSize at startup', async function () {
   await close
 
   const data = await readFileAsync(dest)
-  assert.strictEqual(data, 'hello world\nsomething else\n')
+  t.equal(data, 'hello world\nsomething else\n')
 })
 
-test('over the bufferSize at startup (async)', async function () {
+test('over the bufferSize at startup (async)', async function (t) {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 10,
@@ -158,9 +157,9 @@ test('over the bufferSize at startup (async)', async function () {
   const finish = once(stream, 'finish')
   const close = once(stream, 'close')
 
-  assert.ok(stream.write('hello'))
-  assert.ok(!stream.write(' world\n'))
-  assert.ok(!stream.write('something else\n'))
+  t.ok(stream.write('hello'))
+  t.notOk(stream.write(' world\n'))
+  t.notOk(stream.write('something else\n'))
 
   stream.end()
 
@@ -168,10 +167,10 @@ test('over the bufferSize at startup (async)', async function () {
   await close
 
   const data = await readFileAsync(dest)
-  assert.strictEqual(data, 'hello world\nsomething else\n')
+  t.equal(data, 'hello world\nsomething else\n')
 })
 
-test('flushSync sync=false', async function () {
+test('flushSync sync=false', async function (t) {
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 128,
@@ -182,19 +181,17 @@ test('flushSync sync=false', async function () {
 
   const close = once(stream, 'close')
 
-  stream.on('drain', () => {
-    stream.end()
-  })
-
   for (let count = 0; count < 20; count++) {
     stream.write('aaaaaaaaaa')
   }
+
   stream.flushSync()
+  stream.end()
 
   await close
 
   const data = await readFileAsync(dest)
-  assert.strictEqual(data.length, 200)
+  t.equal(data.length, 200)
 })
 
 test('pass down MessagePorts', async function (t) {
@@ -207,19 +204,19 @@ test('pass down MessagePorts', async function (t) {
     },
     sync: false
   })
-  t.after(() => {
+
+  t.teardown(() => {
     stream.end()
   })
 
-  assert.ok(stream.write('hello world\n'))
-  assert.ok(stream.write('something else\n'))
+  t.ok(stream.write('hello world\n'))
+  t.ok(stream.write('something else\n'))
 
   const [strings] = await once(port2, 'message')
-
-  assert.strictEqual(strings, 'hello world\nsomething else\n')
+  t.equal(strings, 'hello world\nsomething else\n')
 })
 
-test('destroy does not error', async function () {
+test('destroy does not error', async function (t) {
   const dest = file()
   const stream = new ThreadStream({
     filename: join(__dirname, 'to-file.js'),
@@ -232,24 +229,24 @@ test('destroy does not error', async function () {
   })
 
   const [err] = await once(stream, 'error')
-  assert.strictEqual(err.message, 'the worker thread exited')
+  t.equal(err.message, 'the worker thread exited')
 
   await new Promise((resolve) => {
     stream.flush((err) => {
-      assert.strictEqual(err.message, 'the worker has exited')
+      t.equal(err.message, 'the worker has exited')
       resolve()
     })
   })
 
-  assert.doesNotThrow(() => stream.flushSync())
-  assert.doesNotThrow(() => stream.end())
+  t.doesNotThrow(() => stream.flushSync())
+  t.doesNotThrow(() => stream.end())
 })
 
-test('syntax error', async function () {
+test('syntax error', async function (t) {
   const stream = new ThreadStream({
     filename: join(__dirname, 'syntax-error.mjs')
   })
 
   const [err] = await once(stream, 'error')
-  assert.strictEqual(err.message, 'Unexpected end of input')
+  t.equal(err.message, 'Unexpected end of input')
 })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -187,7 +187,8 @@ test('flushSync sync=false', async function (t) {
     sync: false
   })
 
-  const drain = once(stream, 'drain')
+  await once(stream, 'ready')
+
   const finish = once(stream, 'finish')
   const close = once(stream, 'close')
 
@@ -196,11 +197,7 @@ test('flushSync sync=false', async function (t) {
   }
 
   stream.flushSync()
-
-  if (stream.writableNeedDrain) {
-    await drain
-  }
-
+  await new Promise((resolve) => setImmediate(resolve))
   stream.end()
 
   await finish

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -179,6 +179,8 @@ test('flushSync sync=false', async function (t) {
     sync: false
   })
 
+  const drain = once(stream, 'drain')
+  const finish = once(stream, 'finish')
   const close = once(stream, 'close')
 
   for (let count = 0; count < 20; count++) {
@@ -186,8 +188,14 @@ test('flushSync sync=false', async function (t) {
   }
 
   stream.flushSync()
+
+  if (stream.writableNeedDrain) {
+    await drain
+  }
+
   stream.end()
 
+  await finish
   await close
 
   const data = await readFileAsync(dest)

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -121,7 +121,7 @@ test('overflow sync=false', async function (t) {
 })
 
 test('over the bufferSize at startup', function (t) {
-  t.plan(6)
+  t.plan(5)
 
   const dest = file()
   const stream = new ThreadStream({
@@ -138,10 +138,6 @@ test('over the bufferSize at startup', function (t) {
     })
   })
 
-  stream.on('close', () => {
-    t.pass('close emitted')
-  })
-
   t.ok(stream.write('hello'))
   t.ok(stream.write(' world\n'))
   t.ok(stream.write('something else\n'))
@@ -150,7 +146,7 @@ test('over the bufferSize at startup', function (t) {
 })
 
 test('over the bufferSize at startup (async)', function (t) {
-  t.plan(6)
+  t.plan(5)
 
   const dest = file()
   const stream = new ThreadStream({
@@ -171,10 +167,6 @@ test('over the bufferSize at startup (async)', function (t) {
       t.error(err)
       t.equal(data, 'hello world\nsomething else\n')
     })
-  })
-
-  stream.on('close', () => {
-    t.pass('close emitted')
   })
 })
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -120,7 +120,9 @@ test('overflow sync=false', async function (t) {
   t.equal(data.length, 200)
 })
 
-test('over the bufferSize at startup', async function (t) {
+test('over the bufferSize at startup', function (t) {
+  t.plan(6)
+
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 10,
@@ -129,23 +131,27 @@ test('over the bufferSize at startup', async function (t) {
     sync: true
   })
 
-  const finish = once(stream, 'finish')
-  const close = once(stream, 'close')
+  stream.on('finish', () => {
+    readFile(dest, 'utf8', (err, data) => {
+      t.error(err)
+      t.equal(data, 'hello world\nsomething else\n')
+    })
+  })
+
+  stream.on('close', () => {
+    t.pass('close emitted')
+  })
 
   t.ok(stream.write('hello'))
   t.ok(stream.write(' world\n'))
   t.ok(stream.write('something else\n'))
 
   stream.end()
-
-  await finish
-  await close
-
-  const data = await readFileAsync(dest)
-  t.equal(data, 'hello world\nsomething else\n')
 })
 
-test('over the bufferSize at startup (async)', async function (t) {
+test('over the bufferSize at startup (async)', function (t) {
+  t.plan(6)
+
   const dest = file()
   const stream = new ThreadStream({
     bufferSize: 10,
@@ -154,20 +160,22 @@ test('over the bufferSize at startup (async)', async function (t) {
     sync: false
   })
 
-  const finish = once(stream, 'finish')
-  const close = once(stream, 'close')
-
   t.ok(stream.write('hello'))
   t.notOk(stream.write(' world\n'))
   t.notOk(stream.write('something else\n'))
 
   stream.end()
 
-  await finish
-  await close
+  stream.on('finish', () => {
+    readFile(dest, 'utf8', (err, data) => {
+      t.error(err)
+      t.equal(data, 'hello world\nsomething else\n')
+    })
+  })
 
-  const data = await readFileAsync(dest)
-  t.equal(data, 'hello world\nsomething else\n')
+  stream.on('close', () => {
+    t.pass('close emitted')
+  })
 })
 
 test('flushSync sync=false', async function (t) {


### PR DESCRIPTION
## Summary
- backport the `test/base.test.js` async structure from main to avoid tap timing flakiness on `v3.x`
- backport the wraparound state serialization fix so the updated base tests do not expose the existing startup corruption bug on Node 20+
- keep the branch focused on `v3.x` CI stability, separate from the watch-mode backport PR

## Testing
- `nvm use 20.18.0 && npm test`
- `nvm use 20.18.0 && node_modules/.bin/tap test/base.test.js` repeated 25 times
