### PR TITLE
fix: handle read index overshoot

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function resetIndexes (stream) {
     Atomics.store(stream[kImpl].state, READ_INDEX, 0)
     Atomics.store(stream[kImpl].state, WRITE_INDEX, 0)
   })
+  Atomics.notify(stream[kImpl].state, READ_INDEX)
 }
 
 class FakeWeakRef {

--- a/lib/wait.js
+++ b/lib/wait.js
@@ -25,10 +25,18 @@ function wait (state, index, expected, timeout, done) {
     const result = Atomics.waitAsync(state, index, current, remaining)
 
     if (result.async) {
-      result.value.then(check)
+      result.value.then((res) => {
+        if (res === 'ok') {
+          const current = Atomics.load(state, index)
+          done(null, current === expected ? 'ok' : 'not-equal')
+          return
+        }
+
+        check()
+      })
     } else {
-      // Value already changed (not-equal) - recheck on next tick
-      setImmediate(check)
+      // Value changed between Atomics.load() and Atomics.waitAsync().
+      setImmediate(done, null, 'not-equal')
     }
   }
 

--- a/lib/wait.js
+++ b/lib/wait.js
@@ -8,10 +8,15 @@ const WAIT_MS = 10000
 function wait (state, index, expected, timeout, done) {
   const max = timeout === Infinity ? Infinity : Date.now() + timeout
 
-  const check = () => {
+  const check = (previous) => {
     const current = Atomics.load(state, index)
     if (current === expected) {
       done(null, 'ok')
+      return
+    }
+
+    if (previous !== undefined && current !== previous) {
+      done(null, 'not-equal')
       return
     }
 
@@ -27,12 +32,12 @@ function wait (state, index, expected, timeout, done) {
     if (result.async) {
       result.value.then((res) => {
         if (res === 'ok') {
-          const current = Atomics.load(state, index)
-          done(null, current === expected ? 'ok' : 'not-equal')
+          const latest = Atomics.load(state, index)
+          done(null, latest === expected ? 'ok' : 'not-equal')
           return
         }
 
-        check()
+        check(current)
       })
     } else {
       // Value changed between Atomics.load() and Atomics.waitAsync().

--- a/test/ready-race-worker.js
+++ b/test/ready-race-worker.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const { parentPort, workerData } = require('node:worker_threads')
+const { WRITE_INDEX, READ_INDEX } = require('../lib/indexes')
+
+const state = new Int32Array(workerData.stateBuf)
+
+parentPort.on('message', (msg) => {
+  if (msg?.code === 'ADVANCE') {
+    const end = Atomics.load(state, WRITE_INDEX)
+    Atomics.store(state, READ_INDEX, end)
+    Atomics.notify(state, READ_INDEX)
+  } else if (msg?.code === 'SHUTDOWN') {
+    process.exit(0)
+  }
+})
+
+parentPort.postMessage({ code: 'READY' })
+parentPort.postMessage({
+  code: 'EVENT',
+  name: 'write-more'
+})

--- a/test/ready.test.js
+++ b/test/ready.test.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { once } = require('node:events')
+const { join } = require('node:path')
+const ThreadStream = require('..')
+
+test('ready is emitted when the read index skips the startup snapshot', { timeout: 5000 }, async function (t) {
+  const previousOverrides = globalThis.__bundlerPathsOverrides
+  globalThis.__bundlerPathsOverrides = {
+    ...previousOverrides,
+    'thread-stream-worker': join(__dirname, 'ready-race-worker.js')
+  }
+
+  t.after(() => {
+    globalThis.__bundlerPathsOverrides = previousOverrides
+  })
+
+  const stream = new ThreadStream({
+    filename: __filename,
+    sync: true
+  })
+  stream.on('error', () => {})
+
+  t.after(async () => {
+    if (!stream.destroyed) {
+      await stream.worker.terminate()
+    }
+  })
+
+  stream.on('write-more', () => {
+    stream.write('b')
+    stream.worker.postMessage({ code: 'ADVANCE' })
+  })
+
+  const ready = once(stream, 'ready')
+  const close = once(stream, 'close')
+
+  stream.write('a')
+  await ready
+  assert.strictEqual(stream.ready, true)
+
+  stream.worker.postMessage({ code: 'SHUTDOWN' })
+  await close
+})

--- a/test/wait.test.js
+++ b/test/wait.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { wait } = require('../lib/wait')
+
+function waitForResult (update) {
+  const state = new Int32Array(new SharedArrayBuffer(4))
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('wait did not complete'))
+    }, 1000)
+
+    wait(state, 0, 1, Infinity, (err, result) => {
+      clearTimeout(timeout)
+
+      if (err) {
+        reject(err)
+        return
+      }
+
+      resolve(result)
+    })
+
+    setImmediate(() => {
+      update(state)
+      Atomics.notify(state, 0)
+    })
+  })
+}
+
+test('wait returns ok when the expected value is reached', async function () {
+  const result = await waitForResult((state) => {
+    Atomics.store(state, 0, 1)
+  })
+
+  assert.strictEqual(result, 'ok')
+})
+
+test('wait returns not-equal when the expected value is skipped', async function () {
+  const result = await waitForResult((state) => {
+    Atomics.store(state, 0, 2)
+  })
+
+  assert.strictEqual(result, 'not-equal')
+})
+
+test('wait returns not-equal when the value cycles back before notification', async function () {
+  const result = await waitForResult((state) => {
+    Atomics.store(state, 0, 2)
+    Atomics.store(state, 0, 0)
+  })
+
+  assert.strictEqual(result, 'not-equal')
+})
+
+test('wait returns not-equal for an error sentinel', async function () {
+  const result = await waitForResult((state) => {
+    Atomics.store(state, 0, -2)
+  })
+
+  assert.strictEqual(result, 'not-equal')
+})

--- a/test/wait.test.js
+++ b/test/wait.test.js
@@ -4,16 +4,17 @@ const { test } = require('node:test')
 const assert = require('node:assert')
 const { wait } = require('../lib/wait')
 
-function waitForResult (update) {
+function waitForResult (update, opts = {}) {
   const state = new Int32Array(new SharedArrayBuffer(4))
+  const waitTimeout = opts.timeout ?? Infinity
 
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
+    const guard = setTimeout(() => {
       reject(new Error('wait did not complete'))
     }, 1000)
 
-    wait(state, 0, 1, Infinity, (err, result) => {
-      clearTimeout(timeout)
+    wait(state, 0, 1, waitTimeout, (err, result) => {
+      clearTimeout(guard)
 
       if (err) {
         reject(err)
@@ -25,7 +26,9 @@ function waitForResult (update) {
 
     setImmediate(() => {
       update(state)
-      Atomics.notify(state, 0)
+      if (opts.notify !== false) {
+        Atomics.notify(state, 0)
+      }
     })
   })
 }
@@ -59,6 +62,37 @@ test('wait returns not-equal for an error sentinel', async function () {
   const result = await waitForResult((state) => {
     Atomics.store(state, 0, -2)
   })
+
+  assert.strictEqual(result, 'not-equal')
+})
+
+test('wait detects a value change after the fallback timeout', async function () {
+  const result = await waitForResult((state) => {
+    Atomics.store(state, 0, 2)
+  }, { notify: false, timeout: 10 })
+
+  assert.strictEqual(result, 'not-equal')
+})
+
+test('wait returns timed-out when the value does not change', async function () {
+  const result = await waitForResult(() => {}, { notify: false, timeout: 10 })
+
+  assert.strictEqual(result, 'timed-out')
+})
+
+test('wait handles a synchronous not-equal result', async function () {
+  const originalWaitAsync = Atomics.waitAsync
+  Atomics.waitAsync = function (state, index, expected, timeout) {
+    Atomics.store(state, index, 2)
+    return originalWaitAsync(state, index, expected, timeout)
+  }
+
+  let result
+  try {
+    result = await waitForResult(() => {}, { notify: false })
+  } finally {
+    Atomics.waitAsync = originalWaitAsync
+  }
 
   assert.strictEqual(result, 'not-equal')
 })


### PR DESCRIPTION
Restore `wait()`'s `not-equal` result when a notified value skips the expected snapshot, allowing `waitForRead()` to resample instead of waiting forever. This also covers values that cycle before notification and error sentinels.

The regression was introduced by #178, whose `Atomics.waitAsync` refactor removed the historical `not-equal` result. #198 later moved the affected logic into `waitForRead()` without correcting it.

Fixes #245
