### PR TITLE
fix: retain ending streams until worker exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,9 +172,11 @@ function onWorkerMessage (msg) {
 
   switch (msg.code) {
     case 'READY':
-      // Replace the FakeWeakRef with a
-      // proper one.
-      this.stream = new WeakRef(stream)
+      // Allow inactive streams to be collected, but retain streams that are
+      // ending until the worker has emitted close.
+      if (!stream[kImpl].ending) {
+        this.stream = new WeakRef(stream)
+      }
 
       waitForRead(stream, () => {
         stream[kImpl].ready = true
@@ -310,6 +312,9 @@ class ThreadStream extends EventEmitter {
     }
 
     this[kImpl].ending = true
+    // The worker normally holds only a weak reference after READY. Keep this
+    // stream alive while its destination runs any asynchronous finalizer.
+    this.worker.stream = new FakeWeakRef(this)
     end(this)
   }
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "scripts": {
     "build": "tsc --noEmit",
     "lint": "eslint",
-    "test": "npm run lint && npm run build && npm run transpile && borp --pattern \"test/*.test.{js,mjs}\"",
-    "test:ci": "npm run lint && npm run transpile && borp --pattern \"test/*.test.{js,mjs}\"",
-    "test:yarn": "npm run transpile && borp --pattern \"test/*.test.js\"",
+    "test": "npm run lint && npm run build && npm run transpile && borp --expose-gc --pattern \"test/*.test.{js,mjs}\"",
+    "test:ci": "npm run lint && npm run transpile && borp --expose-gc --pattern \"test/*.test.{js,mjs}\"",
+    "test:yarn": "npm run transpile && borp --expose-gc --pattern \"test/*.test.js\"",
     "transpile": "sh ./test/ts/transpile.sh"
   },
   "repository": {

--- a/test/end.test.js
+++ b/test/end.test.js
@@ -31,6 +31,41 @@ test('destroy support', function (t, done) {
   stream.end()
 })
 
+test('end keeps the stream alive until close', { skip: typeof global.gc !== 'function' }, function (t, done) {
+  const dest = file()
+
+  const onClose = () => {
+    clearInterval(gcTimer)
+    clearTimeout(timeout)
+    readFile(dest, 'utf8', (err, data) => {
+      assert.ifError(err)
+      assert.strictEqual(data, 'hello world\nsomething else\n')
+      done()
+    })
+  }
+
+  function setup () {
+    const stream = new ThreadStream({
+      filename: join(__dirname, 'to-file-on-final.js'),
+      workerData: { dest },
+      sync: true
+    })
+
+    stream.on('close', onClose)
+    assert.ok(stream.write('hello world\n'))
+    assert.ok(stream.write('something else\n'))
+    stream.end()
+  }
+
+  setup()
+
+  const gcTimer = setInterval(global.gc, 1)
+  const timeout = setTimeout(() => {
+    clearInterval(gcTimer)
+    assert.fail('stream was collected before close')
+  }, 5000)
+})
+
 test('synchronous _final support', function (t, done) {
   const dest = file()
   const stream = new ThreadStream({


### PR DESCRIPTION
## Summary

- retain a strong worker-to-stream reference once `end()` starts
- avoid replacing that reference with a `WeakRef` when `READY` races with `end()`
- run the test suite with `--expose-gc` and add an inline GC regression test, skipped when GC is unavailable

The worker normally switches to a weak stream reference after startup so abandoned streams can be collected. During `end()`, however, stream event listeners may be the only remaining references. Because those listeners only form a self-cycle, GC can collect the stream, terminate its worker through the finalization registry, and prevent `close` from being emitted. This is the timeout seen on Windows/Node 26 in #246 and on `main`.

## Testing

- `npm test`
- regression test repeated 30 times on Windows with Node 26.8.1
- regression test on Windows with Node 20, 22, and 24
